### PR TITLE
Do not url encode the event headers

### DIFF
--- a/lib/switchx/event/event.ex
+++ b/lib/switchx/event/event.ex
@@ -91,7 +91,7 @@ defmodule SwitchX.Event do
   def dump(event) do
     h_part =
       Enum.map(event.headers, fn {h, v} ->
-        String.trim("#{h}: #{URI.encode("#{v}")}", "\n")
+        String.trim("#{h}: #{v}", "\n")
       end)
       |> Enum.join("\n")
 


### PR DESCRIPTION
This library url encodes all the headers and the body params.
This is problematic when we pass arguments with special characters like:
`SwitchX.execute(data.conn, nil, "playback", "{loops=-1}tone_stream://%(300,0,250)")`

⚠️ Not sure why it the lib encodes, and is it safe to remove it for all cases, let's keep the PR open and not merge to master.