### PR TITLE
command and execute

### DIFF
--- a/lib/switchx.ex
+++ b/lib/switchx.ex
@@ -257,6 +257,8 @@ defmodule SwitchX do
     event = put_in(event.headers, Map.put(event.headers, "call-command", "execute"))
     event = put_in(event.headers, Map.put(event.headers, "execute-app-name", application))
     event = put_in(event.headers, Map.put(event.headers, "execute-app-arg", arg))
+    # setting Event-UUID leads to command being enqued in the applications_pending
+    # than in the commands_sent, which will wait for the command to finish execution. 
     # event = put_in(event.headers, Map.put(event.headers, "Event-UUID", UUID.uuid4()))
     send_message(conn, uuid, event, timeout)
   end

--- a/lib/switchx.ex
+++ b/lib/switchx.ex
@@ -415,7 +415,6 @@ defmodule SwitchX do
   end
 
   defp safe_gen_call(conn, command, timeout) do
-    IO.inspect(command)
     :gen_statem.call(conn, command, timeout)
   catch
     :exit, err -> err

--- a/lib/switchx.ex
+++ b/lib/switchx.ex
@@ -257,6 +257,28 @@ defmodule SwitchX do
     event = put_in(event.headers, Map.put(event.headers, "call-command", "execute"))
     event = put_in(event.headers, Map.put(event.headers, "execute-app-name", application))
     event = put_in(event.headers, Map.put(event.headers, "execute-app-arg", arg))
+    # event = put_in(event.headers, Map.put(event.headers, "Event-UUID", UUID.uuid4()))
+    send_message(conn, uuid, event, timeout)
+  end
+
+  @spec command(conn :: pid(), String.t(), application :: String.t(), args :: String.t()) ::
+          event :: SwitchX.Event
+  def command(conn, uuid, application, args) do
+    command(conn, uuid, application, args, SwitchX.Event.new(), @timeout)
+  end
+
+  @spec command(
+          conn :: pid(),
+          uuid :: String.t(),
+          application :: String.t(),
+          args :: String.t(),
+          event :: SwitchX.Event,
+          timeout :: non_neg_integer()
+        ) :: event :: SwitchX.Event
+  def command(conn, uuid, application, arg, event, timeout) do
+    event = put_in(event.headers, Map.put(event.headers, "call-command", "execute"))
+    event = put_in(event.headers, Map.put(event.headers, "execute-app-name", application))
+    event = put_in(event.headers, Map.put(event.headers, "execute-app-arg", arg))
     event = put_in(event.headers, Map.put(event.headers, "Event-UUID", UUID.uuid4()))
     send_message(conn, uuid, event, timeout)
   end
@@ -393,6 +415,7 @@ defmodule SwitchX do
   end
 
   defp safe_gen_call(conn, command, timeout) do
+    IO.inspect(command)
     :gen_statem.call(conn, command, timeout)
   catch
     :exit, err -> err


### PR DESCRIPTION
The lib always sets a Event-UUID in the `SwitchX.execute` method, which will make the command (`application & arg`) to run in the waiting mode (enqueues to `applications_pending`) where as it should have enqueued to` commands_sent` for instantly callback. The lib mistakenly looks for the callback in the commands_sent queue than in the applications_pending, hence it never ends waiting.

The change made in this PR will fix this behaviour by not setting Event-UUID inside the method, which leads to pushing the callback in the `commands_sent` queue correctly.

If caller indeed want's to wait for the command (`application & arg`) to complete, it can either set the Event-UUID explicitly or use a new method `SwitchX.command`. For the waiting mode, the `SwitchX.my_events(data.conn)` must be called first to subscribe to the command (`application & arg`) execution to complete and make the callback.

The name and split of execute and command is inspired by https://gitlab.com/shimaore/esl